### PR TITLE
Fill available parent width. Fixes #7

### DIFF
--- a/src/visuals.css
+++ b/src/visuals.css
@@ -3,6 +3,7 @@
  * 2. Use correct box sizing in Firefox
  * 3. Display overflow in Edge and IE
  * 4. Inherit color correctly in Firefox
+ * 5. Set full width within Flex parent
  */
 hr {
   border-width: 0 0 1px 0; /* 1 */
@@ -12,6 +13,8 @@ hr {
   height: 0;
   overflow: visible; /* 3 */
   color: inherit; /* 4 */
+  margin-left: 0; /* 5 */
+  margin-right: 0; /* 5 */
 }
 
 figure {


### PR DESCRIPTION
As described in issue #7 this sets margin defaults that allow HRs to appear as one would expect instead of being invisible (a width of zero pixels) due to no spanning happening whatsoever.